### PR TITLE
Implement passing of additional log entry data

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -10,7 +10,8 @@ import (
 // ContextKey is the type for the context key.
 // The Go docs recommend not using any built-in type for context keys in order
 // to ensure that there are no collisions:
-//    https://golang.org/pkg/context/#WithValue
+//
+//	https://golang.org/pkg/context/#WithValue
 type ContextKey string
 
 // ContextKey constants.
@@ -36,10 +37,10 @@ type Formatter struct {
 
 // logEntry is an abbreviated version of the Google "structured logging" data structure.
 type logEntry struct {
-	Message  string            `json:"message"`
-	Severity string            `json:"severity,omitempty"`
-	Trace    string            `json:"logging.googleapis.com/trace,omitempty"`
-	Labels   map[string]string `json:"labels,omitempty"`
+	JSONPayload map[string]any    `json:"jsonPayload"`
+	Severity    string            `json:"severity,omitempty"`
+	Trace       string            `json:"logging.googleapis.com/trace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 // New creates a new formatter.
@@ -71,15 +72,23 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 
 	newEntry := logEntry{
-		Message:  entry.Message,
-		Severity: severity.String(),
-		Labels:   map[string]string{},
+		JSONPayload: entry.Data,
+		Severity:    severity.String(),
+		Labels:      map[string]string{},
 	}
+
+	if newEntry.JSONPayload == nil {
+		newEntry.JSONPayload = map[string]any{}
+	}
+
+	newEntry.JSONPayload["message"] = entry.Message
+
 	if entry.Context != nil {
 		if v, okay := entry.Context.Value(ContextKeyTrace).(string); okay {
 			newEntry.Trace = v
 		}
 	}
+
 	for key, value := range f.Labels {
 		newEntry.Labels[key] = value
 	}
@@ -88,5 +97,6 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return append(contents, []byte("\n")...), nil
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -23,7 +23,9 @@ func TestLogEntry(t *testing.T) {
 		{
 			description: "All fields",
 			input: logEntry{
-				Message:  "my-message",
+				JSONPayload: map[string]any{
+					"message": "my-message",
+				},
 				Severity: "my-severity",
 				Trace:    "my-trace",
 				Labels: map[string]string{
@@ -59,6 +61,9 @@ func TestFormat(t *testing.T) {
 			description: "Empty",
 			input:       logrus.NewEntry(logger),
 			output: logEntry{
+				JSONPayload: map[string]any{
+					"message": "",
+				},
 				Severity: "Emergency", // logrus's 0th level is PanicLevel.
 			},
 		},
@@ -68,10 +73,13 @@ func TestFormat(t *testing.T) {
 				e := logrus.NewEntry(logger)
 				e.Message = "test"
 				e.Level = logrus.InfoLevel
+
 				return e
 			}(),
 			output: logEntry{
-				Message:  "test",
+				JSONPayload: map[string]any{
+					"message": "test",
+				},
 				Severity: "Info",
 			},
 		},
@@ -81,10 +89,13 @@ func TestFormat(t *testing.T) {
 				e := logrus.NewEntry(logger)
 				e.Message = "test"
 				e.Level = logrus.WarnLevel
+
 				return e
 			}(),
 			output: logEntry{
-				Message:  "test",
+				JSONPayload: map[string]any{
+					"message": "test",
+				},
 				Severity: "Warning",
 			},
 		},
@@ -95,10 +106,13 @@ func TestFormat(t *testing.T) {
 				e := logrus.NewEntry(logger).WithContext(ctx)
 				e.Message = "test"
 				e.Level = logrus.InfoLevel
+
 				return e
 			}(),
 			output: logEntry{
-				Message:  "test",
+				JSONPayload: map[string]any{
+					"message": "test",
+				},
 				Severity: "Info",
 				Trace:    "trace-1",
 			},
@@ -110,10 +124,40 @@ func TestFormat(t *testing.T) {
 				e := logrus.NewEntry(logger).WithContext(ctx)
 				e.Message = "test"
 				e.Level = logrus.InfoLevel
+
 				return e
 			}(),
 			output: logEntry{
-				Message:  "test",
+				JSONPayload: map[string]any{
+					"message": "test",
+				},
+				Severity: "Info",
+			},
+		},
+		{
+			description: "With logrus fields",
+			input: func() *logrus.Entry {
+				e := logrus.NewEntry(logger).
+					WithFields(logrus.Fields{
+						"key-1": "value-1",
+						"nested": logrus.Fields{
+							"key-2": "value-2",
+						},
+					})
+
+				e.Message = "test"
+				e.Level = logrus.InfoLevel
+
+				return e
+			}(),
+			output: logEntry{
+				JSONPayload: map[string]any{
+					"message": "test",
+					"key-1":   "value-1",
+					"nested": map[string]any{
+						"key-2": "value-2",
+					},
+				},
 				Severity: "Info",
 			},
 		},


### PR DESCRIPTION
Additional data can be set as logrus fields on the entry and are now passed through to the modified JSON payload. In order to do so the `message` field was moved to jsonPayload, as specified in the [docs](https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_fields).

Fixes #5.